### PR TITLE
Fix O2 login

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<addon id="plugin.video.waipu.tv" name="Waipu.tv" version="0.2.4" provider-name="flubshi, MiRo">
+<addon id="plugin.video.waipu.tv" name="Waipu.tv" version="0.2.5" provider-name="flubshi, MiRo">
 <requires>
   <import addon="xbmc.python" version="2.25.0"/>
   <import addon="script.module.requests" version="2.12.4"/>
@@ -30,6 +30,7 @@
     <screenshot>resources/screenshots/screenshot-03.jpg</screenshot>
   </assets>
   <news>
+- 0.2.5 Improve O2 error handling
 - 0.2.4 Implement O2 Authentication
 - 0.2.3 Fix: recordings are not displayed
 - 0.2.2 rework settings; display account/network status; add metadata; hide locked recordings


### PR DESCRIPTION
In some cases, the base64 encoded token is broken at "subscription". This workaround splits the broken string before decoding and adds a dummy subscription.